### PR TITLE
Automatically load conversations upon selecting a file.

### DIFF
--- a/index.html
+++ b/index.html
@@ -473,6 +473,17 @@
             setLanguage('fr');
         });
 
+		// Add event listener for the 'change' event
+		fileInput.addEventListener('change', handleFileSelect);
+		
+		// read immediately upon file select
+		function handleFileSelect(event) {
+			const file = event.target.files[0]; // Get the selected file
+			if (file) {
+			readConversations();
+			}
+		}
+        
         function setLanguage(lang) {
             currentLanguage = lang;
 
@@ -521,7 +532,8 @@
             mangle: false          // Disable escaping certain characters
         });
 
-        loadButton.addEventListener('click', function () {
+        loadButton.addEventListener('click', readConversations);
+        function readConversations() {
             const file = fileInput.files[0];
             if (!file) {
                 alert(translations[currentLanguage].fileLabel);

--- a/index.html
+++ b/index.html
@@ -557,7 +557,7 @@
                 }
             };
             reader.readAsText(file);
-        });
+        }
 
         function renderConversations(data) {
             if (!Array.isArray(data) || data.length === 0) {


### PR DESCRIPTION
As soon as the conversations.json file is selected, it can be read. The interface may not need a separate "load" button, but it still works if the user wishes to manually reload the same file.

separated out the function, `readConversations` which is still attached to the "Load" button, and is also called automatically when the contents of the file selection is set.

THANK YOU for creating this!  I have wanted something like this for a long while. Merci!